### PR TITLE
Ad an identifier to the talks in talk section

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                   <a href="http://docs.moosex-dic.org/" target="_blank">http://docs.moosex-dic.org/</a>
                 </li>
                 <li class="icon fa-clone" id="t04" >
-                  <h3>Builing a markdown parser only with functions</h3>
+                  <h3>Building a markdown parser only with functions</h3>
                   <h4>Pau Cervera i Badia</h4>
                   <p>
                     We show how to build a nontrivial parser using a functional language such as

--- a/index.html
+++ b/index.html
@@ -126,14 +126,14 @@
                 </p>
               </header>
               <ul id="talk-list" class="features">
-                <li class="icon fa-random">
+                <li class="icon fa-random" id="t01">
                   <h3>Spiders, Gophers & Butterflies</h3>
                   <h4>Sue Spencer</h4>
                   <p>
                     A little Go vs Perl 6 concurrency
                   </p>
                 </li>
-                <li class="icon fa-desktop">
+                <li class="icon fa-desktop" id="t02">
                   <h3>Ravada VDI</h3>
                   <h4>Francesc Guasch</h4>
                   <p>
@@ -142,7 +142,7 @@
                   </p>
                   <a href="http://ravada.upc.edu/" target="_blank">http://ravada.upc.edu/</a>
                 </li>
-                <li class="icon fa-bullseye">
+                <li class="icon fa-bullseye" id="t03">
                   <h3>MooseX::DIC Type-Constrained Dependency Injection</h3>
                   <h4>Loïc Prieto</h4>
                   <p>
@@ -152,7 +152,7 @@
                   </p>
                   <a href="http://docs.moosex-dic.org/" target="_blank">http://docs.moosex-dic.org/</a>
                 </li>
-                <li class="icon fa-clone">
+                <li class="icon fa-clone" id="t04" >
                   <h3>Builing a markdown parser only with functions</h3>
                   <h4>Pau Cervera i Badia</h4>
                   <p>

--- a/index.html
+++ b/index.html
@@ -126,14 +126,14 @@
                 </p>
               </header>
               <ul id="talk-list" class="features">
-                <li class="icon fa-random" id="t01">
+                <li class="icon fa-random" id="talks/spiders-gophers-and-butterflies">
                   <h3>Spiders, Gophers & Butterflies</h3>
                   <h4>Sue Spencer</h4>
                   <p>
                     A little Go vs Perl 6 concurrency
                   </p>
                 </li>
-                <li class="icon fa-desktop" id="t02">
+                <li class="icon fa-desktop" id="talks/ravada-vdi">
                   <h3>Ravada VDI</h3>
                   <h4>Francesc Guasch</h4>
                   <p>
@@ -142,7 +142,7 @@
                   </p>
                   <a href="http://ravada.upc.edu/" target="_blank">http://ravada.upc.edu/</a>
                 </li>
-                <li class="icon fa-bullseye" id="t03">
+                <li class="icon fa-bullseye" id="talks/moosex-dic-type-constrained-dependency-injection">
                   <h3>MooseX::DIC Type-Constrained Dependency Injection</h3>
                   <h4>Loïc Prieto</h4>
                   <p>
@@ -152,7 +152,7 @@
                   </p>
                   <a href="http://docs.moosex-dic.org/" target="_blank">http://docs.moosex-dic.org/</a>
                 </li>
-                <li class="icon fa-clone" id="t04" >
+                <li class="icon fa-clone" id="talks/building-a-markdown-parser-only-with-functions" >
                   <h3>Building a markdown parser only with functions</h3>
                   <h4>Pau Cervera i Badia</h4>
                   <p>


### PR DESCRIPTION
It allows us to refer directly to a talk from the URL
it will permit us  to create personalized twitter cards for the talks