### PR TITLE
Fix Sue's talk meta

### DIFF
--- a/2017/talks/spiders-gophers-and-butterflies.html
+++ b/2017/talks/spiders-gophers-and-butterflies.html
@@ -2,7 +2,7 @@
   <head>
     <title>Barcelona Perl & Friends 2017</title>
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content= "'SPIDERS, GOPHERS & BUTTERFLIES' by Sue Spencer"/>
+    <meta name="twitter:title" content= "'Spiders, Gophers & Butterflies' by Sue Spence"/>
     <meta property="og:site_name" content="Barcelona Perl & Friends 2017"/>
     <meta property="og:url" content="friends.barcelona.pm" />
     <meta property="og:description" content="A little Go vs Perl 6 concurrency" />


### PR DESCRIPTION
Sue's surename has a typo and the talk title wasn't submitted in uppercase.
