### PR TITLE
Prevent cpanfile.snapshot to change between builds

### DIFF
--- a/2018/_src/build
+++ b/2018/_src/build
@@ -13,7 +13,7 @@ else
   export PERL5LIB=$(pwd)/local/lib/perl5:$PERL5LIB
 
   cpanm --local-lib=$(pwd)/local -nq Carton
-  ./local/bin/carton install
+  ./local/bin/carton install --deployment
 
   $(pwd)/bin/build.pl $*
 fi


### PR DESCRIPTION
If we use carton without '--deployment' it will recreate a
cpanfile.snapshot on every run. What we really want is to use the same
snapshot to ensure we are all using the same versions.