### PR TITLE
Update 'All your cluster are belong to us' icon

### DIFF
--- a/2018/_src/config.yml
+++ b/2018/_src/config.yml
@@ -91,6 +91,6 @@ talks:
    slug: 'all-your-cluster-are-belong-to-us'
    description: >
        In this talk I’ll present how we manage our fleet of database clusters at Schibsted using immutable infrastructure and continuous delivery. We offer Kafka and Cassandra as a managed service for other teams at the company with over 50 clusters and how we manage it with a small team of 5 people.
-   icon: 'fa-user-secret'
+   icon: 'fa-space-shuttle'
    duration: 20
    accepted: true

--- a/2018/index.html
+++ b/2018/index.html
@@ -327,7 +327,7 @@ Novetats i estat del projecte Linkat al 2018
         
           
             
-            <li class="icon fa-user-secret" id="/talks/all-your-cluster-are-belong-to-us">
+            <li class="icon fa-space-shuttle" id="/talks/all-your-cluster-are-belong-to-us">
               
 
               <h3>All your cluster are belong to us</h3>


### PR DESCRIPTION
We we're using the icon user-secret for two talks (this one and 'eBPF,
the secret weapon of linux'). To let every talk have a distinctive icon
I've chosen a new one for Jorge's talk.

I choose 'fa-space-shuttle' as a reference for 'Zero Wing', the
videogame where the meme AYBABTU comes from (https://en.wikipedia.org/wiki/All_your_base_are_belong_to_us)